### PR TITLE
Fügt die WorkerConfig zur ETW-Inputnode hinzu

### DIFF
--- a/externaltask-input.html
+++ b/externaltask-input.html
@@ -6,12 +6,22 @@
             name: { value: '' },
             engine: { value: '', type: 'processcube-engine-config' },
             topic: { value: '' },
+            workerConfig: { value: '', type: 'json' },
         },
         inputs: 0,
         outputs: 1,
         icon: 'externaltask_input.svg',
         label: function () {
             return this.name || 'externaltask-input';
+        },
+        oneditprepare: function () {
+            $('#node-input-workerConfig').typedInput({
+                default: 'json',
+                types: ['json'],
+            });
+        },
+        oneditsave: function () {
+            this.workerConfig = $('#node-input-workerConfig').typedInput('value');
         },
     });
 </script>
@@ -28,6 +38,10 @@
     <div class="form-row">
         <label for="node-input-topic"><i class="fa fa-tag"></i> Topic</label>
         <input type="text" id="node-input-topic" placeholder="Topic of ExternalTask" />
+    </div>
+    <div class="form-row"></div>
+        <label for="node-input-workerConfig"><i class="fa fa-tag"></i> Worker Config</label>
+        <input type="text" id="node-input-workerConfig" />
     </div>
 </script>
 

--- a/externaltask-input.js
+++ b/externaltask-input.js
@@ -16,7 +16,7 @@ module.exports = function (RED) {
         var node = this;
         var flowContext = node.context().flow;
 
-        const engine =  RED.nodes.getNode(config.engine);
+        const engine = RED.nodes.getNode(config.engine);
 
         const client = engine.engineClient;
 
@@ -32,82 +32,84 @@ module.exports = function (RED) {
             eventEmitter = flowContext.get('emitter');
         }
 
-        client.externalTasks
-            .subscribeToExternalTaskTopic(config.topic, async (payload, externalTask) => {
-                const saveHandleCallback = (data, callback) => {
-                    try {
-                        callback(data);
-                    } catch (error) {
-                        node.error(`Error in callback 'saveHandleCallback': ${error.message}`);
+        const etwCallback = async (payload, externalTask) => {
+            const saveHandleCallback = (data, callback) => {
+                try {
+                    callback(data);
+                } catch (error) {
+                    node.error(`Error in callback 'saveHandleCallback': ${error.message}`);
+                }
+            };
+
+            return await new Promise((resolve, reject) => {
+                const handleFinishTask = (msg) => {
+                    let result = RED.util.encodeObject(msg.payload);
+
+                    node.log(
+                        `handle event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* ${externalTask.processInstanceId} with result ${result} on msg._msgid ${msg._msgid}.`
+                    );
+
+                    if (externalTask.flowNodeInstanceId) {
+                        delete started_external_tasks[externalTask.flowNodeInstanceId];
                     }
-                };
-
-                return await new Promise((resolve, reject) => {
-                    const handleFinishTask = (msg) => {
-                        let result = RED.util.encodeObject(msg.payload);
-
-                        node.log(
-                            `handle event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* ${externalTask.processInstanceId} with result ${result} on msg._msgid ${msg._msgid}.`,
-                        );
-
-                        if (externalTask.flowNodeInstanceId) {
-                            delete started_external_tasks[externalTask.flowNodeInstanceId];
-                        }
-
-                        showStatus(node, Object.keys(started_external_tasks).length);
-
-                        //resolve(result);
-                        saveHandleCallback(result, resolve);
-                    };
-
-                    const handleErrorTask = (msg) => {
-                        node.log(
-                            `handle error event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' on *msg._msgid* '${msg._msgid}'.`,
-                        );
-
-                        if (externalTask.flowNodeInstanceId) {
-                            delete started_external_tasks[externalTask.flowNodeInstanceId];
-                        }
-
-                        showStatus(node, Object.keys(started_external_tasks).length);
-
-                        // TODO: with reject, the default error handling is proceed
-                        // SEE: https://github.com/5minds/ProcessCube.Engine.Client.ts/blob/develop/src/ExternalTaskWorker.ts#L180
-                        // reject(result);
-                        //resolve(msg);
-                        saveHandleCallback(msg, resolve);
-                    };
-
-                    eventEmitter.once(`handle-${externalTask.flowNodeInstanceId}`, (msg, isError = false) => {
-                        node.log(
-                            `handle event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' with *msg._msgid* '${msg._msgid}' and *isError* '${isError}'`,
-                        );
-
-                        if (isError) {
-                            handleErrorTask(msg);
-                        } else {
-                            handleFinishTask(msg);
-                        }
-                    });
-
-                    started_external_tasks[externalTask.flowNodeInstanceId] = externalTask;
 
                     showStatus(node, Object.keys(started_external_tasks).length);
 
-                    let msg = {
-                        _msgid: RED.util.generateId(),
-                        task: RED.util.encodeObject(externalTask),
-                        payload: payload,
-                        flowNodeInstanceId: externalTask.flowNodeInstanceId,
-                    };
+                    //resolve(result);
+                    saveHandleCallback(result, resolve);
+                };
 
+                const handleErrorTask = (msg) => {
                     node.log(
-                        `Received *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' with *msg._msgid* '${msg._msgid}'`,
+                        `handle error event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' on *msg._msgid* '${msg._msgid}'.`
                     );
 
-                    node.send(msg);
+                    if (externalTask.flowNodeInstanceId) {
+                        delete started_external_tasks[externalTask.flowNodeInstanceId];
+                    }
+
+                    showStatus(node, Object.keys(started_external_tasks).length);
+
+                    // TODO: with reject, the default error handling is proceed
+                    // SEE: https://github.com/5minds/ProcessCube.Engine.Client.ts/blob/develop/src/ExternalTaskWorker.ts#L180
+                    // reject(result);
+                    //resolve(msg);
+                    saveHandleCallback(msg, resolve);
+                };
+
+                eventEmitter.once(`handle-${externalTask.flowNodeInstanceId}`, (msg, isError = false) => {
+                    node.log(
+                        `handle event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' with *msg._msgid* '${msg._msgid}' and *isError* '${isError}'`
+                    );
+
+                    if (isError) {
+                        handleErrorTask(msg);
+                    } else {
+                        handleFinishTask(msg);
+                    }
                 });
-            })
+
+                started_external_tasks[externalTask.flowNodeInstanceId] = externalTask;
+
+                showStatus(node, Object.keys(started_external_tasks).length);
+
+                let msg = {
+                    _msgid: RED.util.generateId(),
+                    task: RED.util.encodeObject(externalTask),
+                    payload: payload,
+                    flowNodeInstanceId: externalTask.flowNodeInstanceId,
+                };
+
+                node.log(
+                    `Received *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' with *msg._msgid* '${msg._msgid}'`
+                );
+
+                node.send(msg);
+            });
+        };
+
+        client.externalTasks
+            .subscribeToExternalTaskTopic(config.topic, etwCallback, config.workerConfig)
             .then(async (externalTaskWorker) => {
                 node.status({ fill: 'blue', shape: 'ring', text: 'subcribed' });
 


### PR DESCRIPTION
Fügt die Config im Node-RED Node-Editor hinzu, sodass man Eigenschaften wie 'lockDuration' oder 'maxTasks' direkt in Node-RED einstellen kann.