### PR TITLE
add event to sub nodes when new engine client was created

### DIFF
--- a/endevent-finished-listener.js
+++ b/endevent-finished-listener.js
@@ -4,7 +4,13 @@ module.exports = function (RED) {
         var node = this;
         node.engine = RED.nodes.getNode(config.engine);
 
+        let subscription = null;
+
         const eventEmitter = node.engine.eventEmitter;
+
+        eventEmitter.on('engine-client-dispose', () => {
+            node.engine.engineClient.events.removeSubscription(subscription, node.engine.identity);
+        });
 
         eventEmitter.on('engine-client-changed', () => {
             node.log('new engineClient received');
@@ -20,8 +26,6 @@ module.exports = function (RED) {
             }
 
             let currentIdentity = node.engine.identity;
-
-            let subscription = null;
 
             try {
                 subscription = await client.events.onEndEventFinished(

--- a/endevent-finished-listener.js
+++ b/endevent-finished-listener.js
@@ -7,7 +7,7 @@ module.exports = function (RED) {
         const eventEmitter = node.engine.eventEmitter;
 
         eventEmitter.on('engine-client-changed', () => {
-            console.log('new engineClient received');
+            node.log('new engineClient received');
             register();
         });
 

--- a/externaltask-event-listener.js
+++ b/externaltask-event-listener.js
@@ -4,6 +4,13 @@ module.exports = function (RED) {
         var node = this;
         node.engine = RED.nodes.getNode(config.engine);
 
+        const eventEmitter = node.engine.eventEmitter;
+
+        eventEmitter.on('engine-client-changed', () => {
+            console.log('new engineClient received');
+            register();
+        });
+
         const register = async () => {
             let currentIdentity = node.engine.identity;
 

--- a/externaltask-event-listener.js
+++ b/externaltask-event-listener.js
@@ -4,7 +4,13 @@ module.exports = function (RED) {
         var node = this;
         node.engine = RED.nodes.getNode(config.engine);
 
+        let subscription;
+
         const eventEmitter = node.engine.eventEmitter;
+
+        eventEmitter.on('engine-client-dispose', () => {
+            node.engine.engineClient.notification.removeSubscription(subscription, node.engine.identity);
+        });
 
         eventEmitter.on('engine-client-changed', () => {
             node.log('new engineClient received');
@@ -20,8 +26,6 @@ module.exports = function (RED) {
                 node.error('No engine configured.');
                 return;
             }
-
-            let subscription;
 
             function externalTaskCallback() {
                 return (externalTaskNotification) => {

--- a/externaltask-event-listener.js
+++ b/externaltask-event-listener.js
@@ -7,7 +7,7 @@ module.exports = function (RED) {
         const eventEmitter = node.engine.eventEmitter;
 
         eventEmitter.on('engine-client-changed', () => {
-            console.log('new engineClient received');
+            node.log('new engineClient received');
             register();
         });
 

--- a/externaltask-input.js
+++ b/externaltask-input.js
@@ -35,7 +35,7 @@ module.exports = function (RED) {
         const engineEventEmitter = node.engine.eventEmitter;
 
         engineEventEmitter.on('engine-client-changed', () => {
-            console.log('new engineClient received');
+            node.log('new engineClient received');
             register();
         });
 

--- a/externaltask-input.js
+++ b/externaltask-input.js
@@ -34,6 +34,10 @@ module.exports = function (RED) {
 
         const engineEventEmitter = node.engine.eventEmitter;
 
+        engineEventEmitter.on('engine-client-dispose', () => {
+            node.engine.engineClient.externalTasks.removeSubscription(subscription, node.engine.identity);
+        });
+
         engineEventEmitter.on('engine-client-changed', () => {
             node.log('new engineClient received');
             register();

--- a/externaltask-input.js
+++ b/externaltask-input.js
@@ -32,132 +32,149 @@ module.exports = function (RED) {
             eventEmitter = flowContext.get('emitter');
         }
 
-        const etwCallback = async (payload, externalTask) => {
-            const saveHandleCallback = (data, callback) => {
-                try {
-                    callback(data);
-                } catch (error) {
-                    node.error(`Error in callback 'saveHandleCallback': ${error.message}`);
-                }
+        const engineEventEmitter = node.engine.eventEmitter;
+
+        engineEventEmitter.on('engine-client-changed', () => {
+            console.log('new engineClient received');
+            register();
+        });
+
+        const register = async () => {
+            const etwCallback = async (payload, externalTask) => {
+                const saveHandleCallback = (data, callback) => {
+                    try {
+                        callback(data);
+                    } catch (error) {
+                        node.error(`Error in callback 'saveHandleCallback': ${error.message}`);
+                    }
+                };
+
+                return await new Promise((resolve, reject) => {
+                    const handleFinishTask = (msg) => {
+                        let result = RED.util.encodeObject(msg.payload);
+
+                        node.log(
+                            `handle event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* ${externalTask.processInstanceId} with result ${result} on msg._msgid ${msg._msgid}.`
+                        );
+
+                        if (externalTask.flowNodeInstanceId) {
+                            delete started_external_tasks[externalTask.flowNodeInstanceId];
+                        }
+
+                        showStatus(node, Object.keys(started_external_tasks).length);
+
+                        //resolve(result);
+                        saveHandleCallback(result, resolve);
+                    };
+
+                    const handleErrorTask = (msg) => {
+                        node.log(
+                            `handle error event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' on *msg._msgid* '${msg._msgid}'.`
+                        );
+
+                        if (externalTask.flowNodeInstanceId) {
+                            delete started_external_tasks[externalTask.flowNodeInstanceId];
+                        }
+
+                        showStatus(node, Object.keys(started_external_tasks).length);
+
+                        // TODO: with reject, the default error handling is proceed
+                        // SEE: https://github.com/5minds/ProcessCube.Engine.Client.ts/blob/develop/src/ExternalTaskWorker.ts#L180
+                        // reject(result);
+                        //resolve(msg);
+                        saveHandleCallback(msg, resolve);
+                    };
+
+                    eventEmitter.once(`handle-${externalTask.flowNodeInstanceId}`, (msg, isError = false) => {
+                        node.log(
+                            `handle event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' with *msg._msgid* '${msg._msgid}' and *isError* '${isError}'`
+                        );
+
+                        if (isError) {
+                            handleErrorTask(msg);
+                        } else {
+                            handleFinishTask(msg);
+                        }
+                    });
+
+                    started_external_tasks[externalTask.flowNodeInstanceId] = externalTask;
+
+                    showStatus(node, Object.keys(started_external_tasks).length);
+
+                    let msg = {
+                        _msgid: RED.util.generateId(),
+                        task: RED.util.encodeObject(externalTask),
+                        payload: payload,
+                        flowNodeInstanceId: externalTask.flowNodeInstanceId,
+                        processInstanceId: externalTask.processInstanceId,
+                    };
+
+                    node.log(
+                        `Received *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' with *msg._msgid* '${msg._msgid}'`
+                    );
+
+                    node.send(msg);
+                });
             };
 
-            return await new Promise((resolve, reject) => {
-                const handleFinishTask = (msg) => {
-                    let result = RED.util.encodeObject(msg.payload);
+            client.externalTasks
+                .subscribeToExternalTaskTopic(
+                    config.topic,
+                    etwCallback,
+                    RED.util.evaluateNodeProperty(config.workerConfig, 'json', node)
+                )
+                .then(async (externalTaskWorker) => {
+                    node.status({ fill: 'blue', shape: 'ring', text: 'subcribed' });
 
-                    node.log(
-                        `handle event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* ${externalTask.processInstanceId} with result ${result} on msg._msgid ${msg._msgid}.`
-                    );
+                    externalTaskWorker.identity = engine.identity;
+                    engine.registerOnIdentityChanged((identity) => {
+                        externalTaskWorker.identity = identity;
+                    });
 
-                    if (externalTask.flowNodeInstanceId) {
-                        delete started_external_tasks[externalTask.flowNodeInstanceId];
+                    // export type WorkerErrorHandler = (errorType: 'fetchAndLock' | 'extendLock' | 'processExternalTask' | 'finishExternalTask', error: Error, externalTask?: ExternalTask<any>) => void;
+                    externalTaskWorker.onWorkerError((errorType, error, externalTask) => {
+                        switch (errorType) {
+                            case 'extendLock':
+                            case 'finishExternalTask':
+                            case 'processExternalTask':
+                                node.error(
+                                    `Worker error ${errorType} for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}': ${error.message}`
+                                );
+
+                                if (externalTask) {
+                                    delete started_external_tasks[externalTask.flowNodeInstanceId];
+                                }
+
+                                showStatus(node, Object.keys(started_external_tasks).length);
+                                break;
+                            default:
+                                node.error(`Worker error ${errorType}: ${error.message}`);
+                                break;
+                        }
+                    });
+
+                    try {
+                        externalTaskWorker.start();
+                    } catch (error) {
+                        node.error(`Worker start 'externalTaskWorker.start' failed: ${error.message}`);
                     }
 
-                    showStatus(node, Object.keys(started_external_tasks).length);
-
-                    //resolve(result);
-                    saveHandleCallback(result, resolve);
-                };
-
-                const handleErrorTask = (msg) => {
-                    node.log(
-                        `handle error event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' on *msg._msgid* '${msg._msgid}'.`
-                    );
-
-                    if (externalTask.flowNodeInstanceId) {
-                        delete started_external_tasks[externalTask.flowNodeInstanceId];
-                    }
-
-                    showStatus(node, Object.keys(started_external_tasks).length);
-
-                    // TODO: with reject, the default error handling is proceed
-                    // SEE: https://github.com/5minds/ProcessCube.Engine.Client.ts/blob/develop/src/ExternalTaskWorker.ts#L180
-                    // reject(result);
-                    //resolve(msg);
-                    saveHandleCallback(msg, resolve);
-                };
-
-                eventEmitter.once(`handle-${externalTask.flowNodeInstanceId}`, (msg, isError = false) => {
-                    node.log(
-                        `handle event for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' with *msg._msgid* '${msg._msgid}' and *isError* '${isError}'`
-                    );
-
-                    if (isError) {
-                        handleErrorTask(msg);
-                    } else {
-                        handleFinishTask(msg);
-                    }
+                    node.on('close', () => {
+                        try {
+                            externalTaskWorker.stop();
+                        } catch {
+                            node.error('Client close failed');
+                        }
+                    });
+                })
+                .catch((error) => {
+                    node.error(`Error in subscribeToExternalTaskTopic: ${error.message}`);
                 });
-
-                started_external_tasks[externalTask.flowNodeInstanceId] = externalTask;
-
-                showStatus(node, Object.keys(started_external_tasks).length);
-
-                let msg = {
-                    _msgid: RED.util.generateId(),
-                    task: RED.util.encodeObject(externalTask),
-                    payload: payload,
-                    flowNodeInstanceId: externalTask.flowNodeInstanceId,
-                    processInstanceId: externalTask.processInstanceId
-                };
-
-                node.log(
-                    `Received *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}' with *msg._msgid* '${msg._msgid}'`
-                );
-
-                node.send(msg);
-            });
         };
 
-        client.externalTasks
-            .subscribeToExternalTaskTopic(config.topic, etwCallback, RED.util.evaluateNodeProperty(config.workerConfig, 'json', node))
-            .then(async (externalTaskWorker) => {
-                node.status({ fill: 'blue', shape: 'ring', text: 'subcribed' });
-
-                externalTaskWorker.identity = engine.identity;
-                engine.registerOnIdentityChanged((identity) => {
-                    externalTaskWorker.identity = identity;
-                });
-
-                // export type WorkerErrorHandler = (errorType: 'fetchAndLock' | 'extendLock' | 'processExternalTask' | 'finishExternalTask', error: Error, externalTask?: ExternalTask<any>) => void;
-                externalTaskWorker.onWorkerError((errorType, error, externalTask) => {
-                    switch (errorType) {
-                        case 'extendLock':
-                        case 'finishExternalTask':
-                        case 'processExternalTask':
-                            node.error(
-                                `Worker error ${errorType} for *external task flowNodeInstanceId* '${externalTask.flowNodeInstanceId}' and *processInstanceId* '${externalTask.processInstanceId}': ${error.message}`
-                            );
-
-                            if (externalTask) {
-                                delete started_external_tasks[externalTask.flowNodeInstanceId];
-                            }
-
-                            showStatus(node, Object.keys(started_external_tasks).length);
-                            break;
-                        default:
-                            node.error(`Worker error ${errorType}: ${error.message}`);
-                            break;
-                    }
-                });
-
-                try {
-                    externalTaskWorker.start();
-                } catch (error) {
-                    node.error(`Worker start 'externalTaskWorker.start' failed: ${error.message}`);
-                }
-
-                node.on('close', () => {
-                    try {
-                        externalTaskWorker.stop();
-                    } catch {
-                        node.error('Client close failed');
-                    }
-                });
-            })
-            .catch((error) => {
-                node.error(`Error in subscribeToExternalTaskTopic: ${error.message}`);
-            });
+        if (node.engine) {
+            register();
+        }
     }
 
     RED.nodes.registerType('externaltask-input', ExternalTaskInput);

--- a/process-event-listener.js
+++ b/process-event-listener.js
@@ -4,6 +4,13 @@ module.exports = function (RED) {
         var node = this;
         node.engine = RED.nodes.getNode(config.engine);
 
+        const eventEmitter = node.engine.eventEmitter;
+
+        eventEmitter.on('engine-client-changed', () => {
+            console.log('new engineClient received');
+            register();
+        });
+
         const register = async () => {
             const client = node.engine.engineClient;
 
@@ -24,7 +31,8 @@ module.exports = function (RED) {
                             async (processNotification) => {
                                 if (
                                     config.processmodel != '' &&
-                                    config.processmodel != processNotification.processModelId) {
+                                    config.processmodel != processNotification.processModelId
+                                ) {
                                     return;
                                 }
 
@@ -65,7 +73,8 @@ module.exports = function (RED) {
                             async (processNotification) => {
                                 if (
                                     config.processmodel != '' &&
-                                    config.processmodel != processNotification.processModelId) {
+                                    config.processmodel != processNotification.processModelId
+                                ) {
                                     return;
                                 }
 
@@ -433,7 +442,6 @@ module.exports = function (RED) {
                     },
                     { identity: currentIdentity }
                 );
-
             });
 
             node.on('close', () => {

--- a/process-event-listener.js
+++ b/process-event-listener.js
@@ -4,7 +4,13 @@ module.exports = function (RED) {
         var node = this;
         node.engine = RED.nodes.getNode(config.engine);
 
+        let subscription;
+
         const eventEmitter = node.engine.eventEmitter;
+
+        engineEventEmitter.on('engine-client-dispose', () => {
+            node.engine.engineClient.notification.removeSubscription(subscription, node.engine.identity);
+        });
 
         eventEmitter.on('engine-client-changed', () => {
             node.log('new engineClient received');
@@ -21,7 +27,6 @@ module.exports = function (RED) {
 
             let currentIdentity = node.engine.identity;
 
-            let subscription;
             const query = RED.util.evaluateNodeProperty(config.query, config.query_type, node);
 
             async function subscribe(eventType) {

--- a/process-event-listener.js
+++ b/process-event-listener.js
@@ -7,7 +7,7 @@ module.exports = function (RED) {
         const eventEmitter = node.engine.eventEmitter;
 
         eventEmitter.on('engine-client-changed', () => {
-            console.log('new engineClient received');
+            node.log('new engineClient received');
             register();
         });
 

--- a/processcube-engine-config.js
+++ b/processcube-engine-config.js
@@ -49,8 +49,9 @@ module.exports = function (RED) {
 
                 node.url = newUrl;
                 if (node.credentials.clientId && node.credentials.clientSecret) {
-                    if (this.engineClient) {
-                        this.engineClient.dispose();
+                    if (node.engineClient) {
+                        node.eventEmitter.emit('engine-client-dispose');
+                        node.engineClient.dispose();
                     }
                     node.engineClient = new engine_client.EngineClient(node.url, () =>
                         getFreshIdentity(node.url, node)
@@ -58,8 +59,9 @@ module.exports = function (RED) {
 
                     node.eventEmitter.emit('engine-client-changed');
                 } else {
-                    if (this.engineClient) {
-                        this.engineClient.dispose();
+                    if (node.engineClient) {
+                        node.eventEmitter.emit('engine-client-dispose');
+                        node.engineClient.dispose();
                     }
                     node.engineClient = new engine_client.EngineClient(node.url);
 

--- a/usertask-event-listener.js
+++ b/usertask-event-listener.js
@@ -4,7 +4,13 @@ module.exports = function (RED) {
         var node = this;
         node.engine = RED.nodes.getNode(config.engine);
 
+        let subscription;
+
         const eventEmitter = node.engine.eventEmitter;
+
+        eventEmitter.on('engine-client-dispose', () => {
+            node.engine.engineClient.userTasks.removeSubscription(subscription, node.engine.identity);
+        });
 
         eventEmitter.on('engine-client-changed', () => {
             node.log('new engineClient received');
@@ -21,7 +27,6 @@ module.exports = function (RED) {
                 return;
             }
 
-            let subscription;
             const query = RED.util.evaluateNodeProperty(config.query, config.query_type, node);
 
             function userTaskCallback() {

--- a/usertask-event-listener.js
+++ b/usertask-event-listener.js
@@ -4,6 +4,13 @@ module.exports = function (RED) {
         var node = this;
         node.engine = RED.nodes.getNode(config.engine);
 
+        const eventEmitter = node.engine.eventEmitter;
+
+        eventEmitter.on('engine-client-changed', () => {
+            console.log('new engineClient received');
+            register();
+        });
+
         const register = async () => {
             let currentIdentity = node.engine.identity;
 
@@ -20,7 +27,7 @@ module.exports = function (RED) {
             function userTaskCallback() {
                 return async (userTaskNotification) => {
                     if (config.usertask != '' && config.usertask != userTaskNotification.flowNodeId) return;
-                    
+
                     const newQuery = {
                         flowNodeInstanceId: userTaskNotification.flowNodeInstanceId,
                         ...query,
@@ -84,7 +91,7 @@ module.exports = function (RED) {
                 currentIdentity = identity;
 
                 subscription = subscribe();
-            })
+            });
 
             node.on('close', async () => {
                 if (node.engine && node.engine.engineClient && client) {

--- a/usertask-event-listener.js
+++ b/usertask-event-listener.js
@@ -7,7 +7,7 @@ module.exports = function (RED) {
         const eventEmitter = node.engine.eventEmitter;
 
         eventEmitter.on('engine-client-changed', () => {
-            console.log('new engineClient received');
+            node.log('new engineClient received');
             register();
         });
 

--- a/wait-for-usertask.js
+++ b/wait-for-usertask.js
@@ -5,13 +5,12 @@ module.exports = function (RED) {
 
         node.engine = RED.nodes.getNode(config.engine);
 
-        const client = node.engine.engineClient;
-
         let subscription = null;
         let currentIdentity = node.engine.identity;
         let subscribe = null;
 
         node.on('input', async function (msg) {
+            const client = node.engine.engineClient;
             subscribe = async () => {
                 if (!client) {
                     node.error('No engine configured.');
@@ -20,44 +19,49 @@ module.exports = function (RED) {
 
                 const query = RED.util.evaluateNodeProperty(config.query, config.query_type, node, msg);
 
-                subscription = await client.userTasks.onUserTaskWaiting(async (userTaskWaitingNotification) => {
+                subscription = await client.userTasks.onUserTaskWaiting(
+                    async (userTaskWaitingNotification) => {
+                        const newQuery = {
+                            flowNodeInstanceId: userTaskWaitingNotification.flowNodeInstanceId,
+                            ...query,
+                        };
 
-                    const newQuery = {
-                        'flowNodeInstanceId': userTaskWaitingNotification.flowNodeInstanceId,
-                        ...query
-                    };
+                        try {
+                            const matchingFlowNodes = await client.userTasks.query(newQuery, {
+                                identity: currentIdentity,
+                            });
 
-                    try {
-                        const matchingFlowNodes = await client.userTasks.query(newQuery, { identity: currentIdentity });
+                            if (matchingFlowNodes.userTasks && matchingFlowNodes.userTasks.length == 1) {
+                                // remove subscription
+                                client.userTasks.removeSubscription(subscription, currentIdentity);
 
-                        if (matchingFlowNodes.userTasks && matchingFlowNodes.userTasks.length == 1) {
-                            // remove subscription
-                            client.userTasks.removeSubscription(subscription, currentIdentity);
+                                const userTask = matchingFlowNodes.userTasks[0];
 
-                            const userTask = matchingFlowNodes.userTasks[0];
-
-                            msg.payload = { userTask: userTask };
-                            node.send(msg);
-                        } else {
-                            // nothing todo - wait for next notification
+                                msg.payload = { userTask: userTask };
+                                node.send(msg);
+                            } else {
+                                // nothing todo - wait for next notification
+                            }
+                        } catch (error) {
+                            node.error(error);
                         }
-                    } catch (error) {
-                        node.error(error);
-                    }
+                    },
+                    { identity: currentIdentity }
+                );
 
-                }, { identity: currentIdentity });
-
-                node.log({ "Handling old userTasks config.only_for_new": config.only_for_new });
+                node.log({ 'Handling old userTasks config.only_for_new': config.only_for_new });
 
                 if (config.only_for_new === false) {
                     // only check suspended user tasks
                     const suspendedQuery = {
-                        'state': 'suspended',
-                        ...query
+                        state: 'suspended',
+                        ...query,
                     };
 
                     try {
-                        const matchingFlowNodes = await client.userTasks.query(suspendedQuery, { identity: currentIdentity });
+                        const matchingFlowNodes = await client.userTasks.query(suspendedQuery, {
+                            identity: currentIdentity,
+                        });
 
                         if (matchingFlowNodes.userTasks && matchingFlowNodes.userTasks.length >= 1) {
                             const userTask = matchingFlowNodes.userTasks[0];
@@ -80,7 +84,6 @@ module.exports = function (RED) {
         });
 
         node.engine.registerOnIdentityChanged(async (identity) => {
-
             if (subscription) {
                 client.userTasks.removeSubscription(subscription, currentIdentity);
                 currentIdentity = identity;
@@ -90,11 +93,11 @@ module.exports = function (RED) {
             }
         });
 
-        node.on("close", async () => {
+        node.on('close', async () => {
             if (client != null && subscription != null) {
                 client.userTasks.removeSubscription(subscription, currentIdentity);
             }
         });
     }
-    RED.nodes.registerType("wait-for-usertask", WaitForUsertask);
-}
+    RED.nodes.registerType('wait-for-usertask', WaitForUsertask);
+};


### PR DESCRIPTION
Die ProcessCube-Engine-Config-Node gibt ein Event aus, auf das sich die Subscription-Nodes subscriben. Wird das Event getriggert, holt die Node sich den aktuellen Client von der Config-Node und baut die Subscriptions neu auf. So wie ich das verstehe, werden beim Aufruf von client.dispose() in der Config-Node bereits die alten Subscriptions abgeräumt, daher müssen diese hier nicht noch einmal separat entfernt werden.