### PR TITLE
Passt die Parameternamen an die der Processinstance-Delete-Node übergeben werden können

### DIFF
--- a/processinstance-delete.html
+++ b/processinstance-delete.html
@@ -6,8 +6,8 @@
             name: { value: '' },
             engine: { value: '', type: 'processcube-engine-config' },
             modelid: { value: '' },
-            time: { value: '', type: 'number' },
-            time_type: { value: 'hours' },
+            duration: { value: '', type: 'number' },
+            time_unit: { value: 'hours' },
         },
         inputs: 1,
         outputs: 1,
@@ -32,12 +32,12 @@
         <input type="text" id="node-input-modelid" />
     </div>
     <div class="form-row">
-        <label for="node-input-time"><i class="fa fa-tag"></i> Duration</label>
+        <label for="node-input-duration"><i class="fa fa-tag"></i> Duration</label>
         <input type="text" id="node-input-time" />
     </div>
     <div class="form-row">
-        <label for="node-input-time_type"><i class="fa fa-sliders"></i> Time Unit</label>
-        <select id="node-input-time_type" style="width: 70%;">
+        <label for="node-input-time_unit"><i class="fa fa-sliders"></i> Time Unit</label>
+        <select id="node-input-time_unit" style="width: 70%;">
             <option value="hours">Hours</option>
             <option value="days">Days</option>
         </select>

--- a/processinstance-delete.html
+++ b/processinstance-delete.html
@@ -49,8 +49,8 @@ Delete old instances of a process model in the ProcessCube.
 
 ## Inputs
 
-: payload.time (number): The number of given time periods.
-: payload.time_type ('hours' | 'days'): The type of time period to use.
+: payload.duration (number): The number of given time units.
+: payload.time_unit ('hours' | 'days'): The unit of time to use.
 
 ## Outputs
 

--- a/processinstance-delete.js
+++ b/processinstance-delete.js
@@ -12,13 +12,13 @@ module.exports = function (RED) {
                 return;
             }
             let timeMultiplier;
-            if (msg.payload.time_type) {
-                timeMultiplier = msg.payload.time_type == 'hours' ? 1 : 24;
+            if (msg.payload.time_unit) {
+                timeMultiplier = msg.payload.time_unit == 'hours' ? 1 : 24;
             } else {
-                timeMultiplier = config.time_type == 'hours' ? 1 : 24;
+                timeMultiplier = config.time_unit == 'hours' ? 1 : 24;
             }
 
-            const timeToUse = msg.payload.time ? msg.payload.time : config.time;
+            const timeToUse = msg.payload.duration ? msg.payload.duration : config.duration;
             const modelId = msg.payload.processModelId
                 ? msg.payload.processModelId != ''
                     ? msg.payload.processModelId


### PR DESCRIPTION
Vor einiger Zeit hatte ich mal die Namen der Input-Felder für die Node angepasst. Dabei hatte ich übersehen, dass man nun nicht mehr die gleichen Namen für die Felder und die Parameter benutzen kann. Dies wird hier angepasst.