### PR TITLE
Fix flat mapping of process models

### DIFF
--- a/processdefinition-query.js
+++ b/processdefinition-query.js
@@ -23,14 +23,8 @@ module.exports = function (RED) {
             client.processDefinitions
                 .getAll(query)
                 .then((matchingProcessDefinitions) => {
-                    if (config.models_only && matchingProcessDefinitions.totalCount > 0) {
-                        let models = [];
-
-                        matchingProcessDefinitions.processDefinitions.forEach((processDefinition) => {
-                            processDefinition.processModels.forEach((model) => {
-                                models.push(model);
-                            });
-                        });
+                    if (config.models_only) {
+                        const models = matchingProcessDefinitions.processDefinitions.flatMap(processDefinition => processDefinition.processModels);
 
                         msg.payload = {
                             models: models,


### PR DESCRIPTION
Wenn es keine Modelle gibt, war bisher das Ergebnis nicht so formatiert, wie es im models_only-Modus sein sollte. Jetzt ist es immer richtig formatiert.