### PR TITLE
Override query, when query is not an object

### DIFF
--- a/processdefinition-query.js
+++ b/processdefinition-query.js
@@ -14,6 +14,10 @@ module.exports = function (RED) {
 
             let query = RED.util.evaluateNodeProperty(config.query, config.query_type, node, msg);
 
+            if (typeof query !== 'object' || Array.isArray(query) || query === null) {
+                query = {};
+            }
+
             node.log(`Querying process definitions with query: ${JSON.stringify(query)}`);
 
             const isUser = !!msg._client?.user && !!msg._client.user.accessToken;


### PR DESCRIPTION
Wenn die Query, die an den Client.ts geht, kein Object ist, dann wird sie mit einem leeren Object überschrieben

![image](https://github.com/user-attachments/assets/9a035196-7853-4196-9e82-16cf6bce51ac)

Wenn man über einen Page-Reload die Tabelle aktualisiert, dann ist die Payload die in die 'processdefinition-query'-Node geht ein Objekt. In dem Fall kommt nicht das richtige Ergebniss von der Engine zurück. Wenn man auf den aktualisieren-Button klickt, dann ist die Payload ein String. Dann stimmt alles im Ergebniss.

Liegt an Folgendem: Die Query-Node versucht intern an die aktuelle Payload das Token des Nutzers anzuhängen. Das funktioniert bei einem String natürlich nicht. Darum wird dann keine Identity mitgeschickt und die Engine verwendet das Standard-Dummy-Token.

https://5minds.atlassian.net/browse/PSD-297