### PR TITLE
Rename vars NODE_RED -> NODERED; Disconnect hooks after Node is closed

### DIFF
--- a/.processcube/nodered/.config.nodes.json
+++ b/.processcube/nodered/.config.nodes.json
@@ -1,7 +1,7 @@
 {
     "node-red": {
         "name": "node-red",
-        "version": "4.0.8",
+        "version": "4.1.1",
         "local": false,
         "user": false,
         "nodes": {
@@ -429,7 +429,7 @@
     },
     "@5minds/node-red-contrib-processcube": {
         "name": "@5minds/node-red-contrib-processcube",
-        "version": "1.16.0",
+        "version": "1.16.1",
         "local": false,
         "user": false,
         "nodes": {

--- a/.processcube/nodered/.config.runtime.json
+++ b/.processcube/nodered/.config.runtime.json
@@ -1,3 +1,4 @@
 {
-    "instanceId": "85440fa479689bf6"
+    "instanceId": "85440fa479689bf6",
+    "telemetryEnabled": false
 }

--- a/.processcube/nodered/.config.users.json
+++ b/.processcube/nodered/.config.users.json
@@ -10,10 +10,11 @@
                 "view-node-status": true,
                 "view-node-show-label": true,
                 "view-show-tips": true,
-                "view-show-welcome-tours": true
+                "view-show-welcome-tours": true,
+                "view-node-info-icon": true
             },
             "tours": {
-                "welcome": "4.0.8"
+                "welcome": "4.1.1"
             },
             "dialog": {
                 "export": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nodered/node-red:4.0.8-22
+FROM nodered/node-red:4.1.1-22
 
 # package 
 USER root

--- a/externaltask-input.js
+++ b/externaltask-input.js
@@ -29,15 +29,15 @@ module.exports = function (RED) {
         }
 
         if (!options['lockDuration'] && (process.env.NODE_RED_ETW_LOCK_DURATION || process.env.NODERED_ETW_LOCK_DURATION)) {
-            options['lockDuration'] = parseInt(process.env.NODE_RED_ETW_LOCK_DURATION) || parseInt(process.env.NODERED_ETW_LOCK_DURATION) || undefined;
+            options['lockDuration'] = parseInt(process.env.NODE_RED_ETW_LOCK_DURATION || process.env.NODERED_ETW_LOCK_DURATION) || undefined;
         }
 
         if (!options['longpollingTimeout']) {
-            options['longpollingTimeout'] = parseInt(process.env.NODE_RED_ETW_LONGPOLLING_TIMEOUT) || parseInt(process.env.NODERED_ETW_LONGPOLLING_TIMEOUT) || undefined;
+            options['longpollingTimeout'] = parseInt(process.env.NODE_RED_ETW_LONGPOLLING_TIMEOUT || process.env.NODERED_ETW_LONGPOLLING_TIMEOUT) || undefined;
         }
 
         if (!options['idleTimeout']) {
-            options['idleTimeout'] = parseInt(process.env.NODE_RED_ETW_IDLE_TIMEOUT) || parseInt(process.env.NODERED_ETW_IDLE_TIMEOUT) || undefined;
+            options['idleTimeout'] = parseInt(process.env.NODE_RED_ETW_IDLE_TIMEOUT || process.env.NODERED_ETW_IDLE_TIMEOUT) || undefined;
         }
 
         node._subscribed = true;

--- a/externaltask-input.js
+++ b/externaltask-input.js
@@ -28,16 +28,16 @@ module.exports = function (RED) {
             options['workerId'] = this.workername;
         }
 
-        if (!options['lockDuration'] && process.env.NODE_RED_ETW_LOCK_DURATION) {
-            options['lockDuration'] = parseInt(process.env.NODE_RED_ETW_LOCK_DURATION) || undefined;
+        if (!options['lockDuration'] && (process.env.NODE_RED_ETW_LOCK_DURATION || process.env.NODERED_ETW_LOCK_DURATION)) {
+            options['lockDuration'] = parseInt(process.env.NODE_RED_ETW_LOCK_DURATION) || parseInt(process.env.NODERED_ETW_LOCK_DURATION) || undefined;
         }
 
         if (!options['longpollingTimeout']) {
-            options['longpollingTimeout'] = parseInt(process.env.NODE_RED_ETW_LONGPOLLING_TIMEOUT) || undefined;
+            options['longpollingTimeout'] = parseInt(process.env.NODE_RED_ETW_LONGPOLLING_TIMEOUT) || parseInt(process.env.NODERED_ETW_LONGPOLLING_TIMEOUT) || undefined;
         }
 
         if (!options['idleTimeout']) {
-            options['idleTimeout'] = parseInt(process.env.NODE_RED_ETW_IDLE_TIMEOUT) || undefined;
+            options['idleTimeout'] = parseInt(process.env.NODE_RED_ETW_IDLE_TIMEOUT) || parseInt(process.env.NODERED_ETW_IDLE_TIMEOUT) || undefined;
         }
 
         node._subscribed = true;
@@ -164,7 +164,7 @@ module.exports = function (RED) {
             }
         };
 
-        RED.hooks.add('preDeliver', (sendEvent) => {
+        const onPreDeliver = (sendEvent) => {
             if (node.isHandling() && node.ownMessage(sendEvent.msg)) {  
                 
                 const sourceNode = sendEvent?.source?.node;
@@ -185,14 +185,15 @@ module.exports = function (RED) {
 
                 node.traceExecution(debugMsg);
 
-                if (process.env.NODE_RED_ETW_STEP_LOGGING == 'true') {
+                if (process.env.NODE_RED_ETW_STEP_LOGGING == 'true' || process.env.NODERED_ETW_STEP_LOGGING == 'true') {
                     node._trace = `'${sourceNode.name || sourceNode.type}'->'${destinationNode.name || destinationNode.type}'`;
                     node.log(`preDeliver: ${node._trace}`);
                 }
             }
-        });
+        };
+        RED.hooks.add('preDeliver', onPreDeliver);
 
-        RED.hooks.add('postDeliver', (sendEvent) => {
+        const onPostDeliver = (sendEvent) => {
             if (node.isHandling() && node.ownMessage(sendEvent.msg)) {
                 const sourceNode = sendEvent?.source?.node;
                 const destinationNode = sendEvent?.destination?.node;
@@ -211,12 +212,13 @@ module.exports = function (RED) {
 
                 node.traceExecution(debugMsg);
 
-                if (process.env.NODE_RED_ETW_STEP_LOGGING == 'true') {
+                if (process.env.NODE_RED_ETW_STEP_LOGGING == 'true' || process.env.NODERED_ETW_STEP_LOGGING == 'true') {
                     node._trace = `'${sourceNode.name || sourceNode.type}'->'${destinationNode.name || destinationNode.type}'`;
                     node.log(`postDeliver: ${node._trace}`);
                 }
             }
-        });
+        };
+        RED.hooks.add('postDeliver', onPostDeliver);
 
         node.setSubscribedStatus = () => {
             this._subscribed = true;
@@ -440,7 +442,7 @@ module.exports = function (RED) {
                     externalTaskWorker.onHeartbeat((event, external_task_id) => {
                         node.setSubscribedStatus();
                         
-                        if (process.env.NODE_RED_ETW_HEARTBEAT_LOGGING  == 'true') {
+                        if (process.env.NODE_RED_ETW_HEARTBEAT_LOGGING  == 'true' || process.env.NODERED_ETW_HEARTBEAT_LOGGING  == 'true') {
                             if (external_task_id) {
                                 this.log(`subscription (heartbeat:topic ${node.topic}, ${event} for ${external_task_id}).`);
                             } else {
@@ -460,7 +462,7 @@ module.exports = function (RED) {
 
                                 node.setUnsubscribedStatus(error);
 
-                                if (process.env.NODE_RED_ETW_STOP_IF_FAILED == 'true') { 
+                                if (process.env.NODE_RED_ETW_STOP_IF_FAILED == 'true' || process.env.NODERED_ETW_STOP_IF_FAILED == 'true') { 
                                     // abort the external task MM: waiting for a fix in the client.ts
                                     externalTaskWorker.abortExternalTaskIfPresent(externalTask.id);
                                     // mark the external task as finished, cause it is gone
@@ -486,7 +488,10 @@ module.exports = function (RED) {
 
                     node.on('close', () => {
                         try {
+                            RED.hooks.remove('preDeliver', onPreDeliver);
+                            RED.hooks.remove('postDeliver', onPostDeliver);
                             externalTaskWorker.stop();
+                            node.log('External Task Worker closed.');
                         } catch {
                             node.error('Client close failed', {});
                         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@5minds/node-red-contrib-processcube",
-    "version": "1.16.0",
+    "version": "1.16.1",
     "license": "MIT",
     "description": "Node-RED nodes for ProcessCube",
     "scripts": {


### PR DESCRIPTION
## Pull Request Overview

This PR renames environment variables from `NODE_RED_*` to `NODERED_*` while maintaining backward compatibility, and fixes a memory leak by properly removing event hooks when the external task node is closed.

**Key Changes:**
- Adds support for new `NODERED_*` environment variable naming convention alongside existing `NODE_RED_*` variables
- Implements proper cleanup of `preDeliver` and `postDeliver` hooks in the node's close handler
- Updates Node-RED version from 4.0.8 to 4.1.1

### Reviewed Changes

Copilot reviewed 6 out of 6 changed files in this pull request and generated 3 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| package.json | Version bump to 1.16.1 |
| externaltask-input.js | Adds NODERED_* env var support, extracts hook callbacks to named functions, and removes hooks on node close |
| Dockerfile | Updates base image to Node-RED 4.1.1-22 |
| .processcube/nodered/.config.users.json | Updates config for Node-RED 4.1.1 with new view settings |
| .processcube/nodered/.config.runtime.json | Adds telemetry disabled flag |
| .processcube/nodered/.config.nodes.json | Updates version references to 4.1.1 and 1.16.1 |
</details>






---

💡 <a href="/5minds/node-red-contrib-processcube/new/develop/.github?filename=*.instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Learn how to get started</a>.